### PR TITLE
Fix links in index.tsx

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -61,14 +61,14 @@ const IndexPage = () => {
       <ul style={listStyles}>
         <li style={listItemStyles}>
           <a style={linkStyle}
-             href={`gadi/all_laws.json.gz`}
+             href={`all_laws.json.gz`}
           >
             Große JSON-Datei (<code>all_laws.json.gz</code>)
           </a>
         </li>
         <li style={listItemStyles}>
           <a style={linkStyle}
-             href={`gadi/all_laws.tar.gz`}
+             href={`all_laws.tar.gz`}
           >
             Tarball mit einzelnen JSON-Dateien je Gesetz (<code>all_laws.tar.gz</code>)
           </a>


### PR DESCRIPTION
Hey, I love your project, but I noticed that 2 links on https://gadi.netlify.app are dead links.

I had to remove `gadi` from the links of these 2 entries:
- [Große JSON-Datei (all_laws.json.gz)](https://gadi.netlify.app/gadi/all_laws.json.gz)
- [Tarball mit einzelnen JSON-Dateien je Gesetz (all_laws.tar.gz)](https://gadi.netlify.app/gadi/all_laws.tar.gz)

The fixed version links to the correct path:
- https://gadi.netlify.app/all_laws.json.gz
- https://gadi.netlify.app/all_laws.tar.gz