### PR TITLE
Update cache action version in ingest workflow

### DIFF
--- a/.github/workflows/ingest-and-deploy.yml
+++ b/.github/workflows/ingest-and-deploy.yml
@@ -44,7 +44,7 @@ jobs:
         DB_URI: postgresql://postgres:secret@postgres:5432/gadi
 
     - name: Cache downloaded data
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ env.DATA_DIR }}
         key: downloaded-files


### PR DESCRIPTION
## Summary
- update the ingest-and-deploy workflow to use actions/cache@v4 for caching downloaded data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4cf6b1c74832aa35dc118b0fff2c4